### PR TITLE
fix🐛: 修复依赖项中潜在的安全漏洞

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3584,7 +3584,7 @@ css-select@^2.0.0:
     boolbase "^1.0.0"
     css-what "^3.2.1"
     domutils "^1.7.0"
-    nth-check "^1.0.2"
+    nth-check "^2.0.1"
 
 css-select@^4.1.3:
   version "4.3.0"


### PR DESCRIPTION
模块 react-scripts@5.0.1 依赖于 nth-check@^1.0.2, 而最新的已修复模块版本为2.0.1
详细解释见: https://martellosecurity.com/kb/mitre/cwe/1333/